### PR TITLE
Remove DeferRendering, Popup, Popover from list of widgets with trans…

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,8 +212,7 @@ render the data where you need inside the template.
 In addition to using dxTemplate, it is possible to put the content of the following widgets directly into the markup: 
 [DxResizable](https://js.devexpress.com/Documentation/16_1/ApiReference/UI_Widgets/dxResizable/), 
 [DxScrollView](https://js.devexpress.com/Documentation/16_1/ApiReference/UI_Widgets/dxScrollView/), 
-[DxPopup](https://js.devexpress.com/Documentation/16_1/ApiReference/UI_Widgets/dxPopup/), 
-[DxPopover](https://js.devexpress.com/Documentation/16_1/ApiReference/UI_Widgets/dxPopover/).
+[DxValidationGroup](https://js.devexpress.com/Documentation/16_1/ApiReference/UI_Widgets/dxValidationGroup/).
 For instance, we can set the content for 
 the [DxScrollView](https://js.devexpress.com/Documentation/16_1/ApiReference/UI_Widgets/dxScrollView/) widget as shown below: 
 

--- a/examples/app/app.component.html
+++ b/examples/app/app.component.html
@@ -103,7 +103,9 @@
 <h2>dxPopup</h2>
 
 <dx-popup showTitle="true" title="Demo of dxPopup" [(visible)]="popupVisible">
-    <div>Hello from dxPopup</div>
+    <div *dxTemplate="let data of 'content'">
+        <div>Hello from dxPopup</div>
+    </div>
 </dx-popup>
 <dx-button text="Show Popup via model" (onClick)="popupVisible = !popupVisible"></dx-button>
 
@@ -115,7 +117,9 @@
     position="top" 
     showTitle="true" 
     title="Demo of dxPopover">
-    <p>Hello from dxPopover</p>
+    <div *dxTemplate="let data of 'content'">
+        <p>Hello from dxPopover</p>
+    </div>
 </dx-popover>
 <dx-button 
     id="popoverButton" 

--- a/metadata/StrongMetaData.json
+++ b/metadata/StrongMetaData.json
@@ -4267,7 +4267,6 @@
     },
     "dxDeferRendering": {
       "Description": "A container for elements that must be rendered at a specified moment.",
-      "IsTranscludedContent": true,
       "Module": "ui/defer_rendering",
       "Options": {
         "onRendered": {
@@ -8586,7 +8585,6 @@
     },
     "dxPopover": {
       "Description": "A widget that displays the required content in a popup window.",
-      "IsTranscludedContent": true,
       "Module": "ui/popover",
       "Options": {
         "onDisposing": {
@@ -8898,7 +8896,6 @@
     },
     "dxPopup": {
       "Description": "A widget that displays required content in a popup window.",
-      "IsTranscludedContent": true,
       "Module": "ui/popup",
       "Options": {
         "onDisposing": {


### PR DESCRIPTION
…cluded content

We have found inconsistent behavior in Component based widgets (eg. ScrollView)
and Widget based widgets (eg. Popup). Second group makes template from content
and copies markup instead of wrapping it.