### PR TITLE
Add template wrapper class to rendered template

### DIFF
--- a/src/core/dx.template.ts
+++ b/src/core/dx.template.ts
@@ -13,6 +13,8 @@ import { DxTemplateHost } from './dx.template-host';
 declare function require(params: any): any;
 let $ = require('jquery');
 
+const DX_TEMPLATE_WRAPPER_CLASS = 'dx-template-wrapper';
+
 export class RenderData {
     model: any;
     itemIndex: number;
@@ -38,7 +40,8 @@ export class DxTemplateDirective {
         // https://github.com/angular/angular/issues/12243
         childView['detectChanges']();
         // =========== /WORKAROUND =============
-        return $(childView.rootNodes);
+        return $(childView.rootNodes)
+            .addClass(DX_TEMPLATE_WRAPPER_CLASS);
     }
     templateAsFunction(model, itemIndex, container) {
         let renderData: RenderData = this._normalizeArguments(model, itemIndex, container);

--- a/tests/src/core/template.spec.ts
+++ b/tests/src/core/template.spec.ts
@@ -149,13 +149,10 @@ describe('DevExtreme Angular 2 widget\'s template', () => {
                 model: {},
                 itemIndex: 0,
                 container: $('<div>')
-            },
-            newDiv = document.createElement('div');
-
-        newDiv.innerHTML = 'Template content';
+            };
 
         let renderResult = template.render(renderData)[0];
-        expect(newDiv.isEqualNode(renderResult)).toBe(true);
+        expect(renderResult.innerHTML).toBe('Template content');
 
         expect(template.owner()).toBe(instance);
 
@@ -208,6 +205,31 @@ describe('DevExtreme Angular 2 widget\'s template', () => {
 
     }));
 
+
+    it('should add template wrapper class as template has root container', async(() => {
+        TestBed.overrideComponent(TestContainerComponent, {
+            set: {
+                template: `
+            <dx-test-widget>
+                <div *dxTemplate="let d of 'testTemplate'">Template content: {{d}}</div>
+            </dx-test-widget>
+           `}
+        });
+        let fixture = TestBed.createComponent(TestContainerComponent);
+        fixture.detectChanges();
+
+        let testComponent = fixture.componentInstance,
+            innerComponent = testComponent.innerWidgets.first,
+            template = innerComponent.testTemplate,
+            $container = $('<div>');
+
+        expect(template).not.toBeUndefined;
+
+        template($container);
+        fixture.detectChanges();
+        expect($container.children().eq(0).hasClass('dx-template-wrapper')).toBe(true);
+
+    }));
 
 });
 


### PR DESCRIPTION
This class is required because our templates have wrapper div on which *dxTemplate directive present

Fixes #168 