### PR TITLE
Revert "fix: Prevent unexpected recursively array options changing"

### DIFF
--- a/templates/component.tst
+++ b/templates/component.tst
@@ -149,16 +149,12 @@ export class <#= it.className #>Component extends <#= baseClass #> <#? implement
     }
 
     _setOption(name: string, value: any) {
-        let changes;
-
         if (Array.isArray(value)) {
             this._idh.setupSingle(name, value);
-            changes = this._idh.getChanges(name, value);
+            this._idh.getChanges(name, value);
         }
 
-        if (changes !== null) {
-            super._setOption(name, value);
-        }
+        super._setOption(name, value);
     }<#?#>
 <#? it.isEditor #>
     ngAfterContentInit() {

--- a/tests/src/ui/list.spec.ts
+++ b/tests/src/ui/list.spec.ts
@@ -90,27 +90,6 @@ describe('DxList', () => {
         instance.option.calls.reset();
     }));
 
-    it('should not react if the identicaly value is assigned to the collection', async(() => {
-        TestBed.overrideComponent(TestContainerComponent, {
-            set: {
-                template: '<dx-list [items]="items"></dx-list>'
-            }
-        });
-        let fixture = TestBed.createComponent(TestContainerComponent);
-        fixture.detectChanges();
-
-        let testComponent = fixture.componentInstance,
-            instance = getWidget(fixture);
-
-        spyOn(instance, 'option').and.callThrough();
-
-        testComponent.items = testComponent.items.slice(0);
-        fixture.detectChanges();
-
-        expect(instance.option).toHaveBeenCalledTimes(1);
-        instance.option.calls.reset();
-    }));
-
     it('should be able to accept items as a static nested components list', async(() => {
         TestBed.overrideComponent(TestContainerComponent, {
             set: {


### PR DESCRIPTION
Reverts DevExpress/devextreme-angular#537

Changes are absent While initializing with array options (undefined -> [])