### PR TITLE
Transitionend event should be subscribed within Angular Zone

### DIFF
--- a/src/core/integration.ts
+++ b/src/core/integration.ts
@@ -9,7 +9,7 @@ import * as readyCallbacks from 'devextreme/core/utils/ready_callbacks';
 import * as eventsEngine from 'devextreme/events/core/events_engine';
 
 const outsideZoneEvents = ['mousemove', 'mouseover', 'mouseout', 'wheel'];
-const insideZoneEvents = ['mouseup', 'click', 'mousedown'];
+const insideZoneEvents = ['mouseup', 'click', 'mousedown', 'transitionend'];
 
 let originalAdd;
 let callbacks = [];


### PR DESCRIPTION
dxMenu renders items on transitionend event. So it should be included in ng zone